### PR TITLE
Fix nixos-rebuild.sh

### DIFF
--- a/scripts/hm-home.bash
+++ b/scripts/hm-home.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 if [[ "$1" == "switch" ]]; then
-  shift 1;
-  switch=y
+	shift 1
+	switch=y
 fi
 
 portable=
@@ -9,30 +9,35 @@ hostattr="$FLAKEROOT#homeConfigurations.\"$USER@$HOST\".activationPackage"
 portableattr="$FLAKEROOT#homeConfigurationsPortable.$ARCH.\"$USER\".activationPackage"
 
 if [[ "$1" == *"@"* ]]; then
-  USER="$(cut -d '@' -f 1 <<< "$1")"
-  HOST="$(cut -d '@' -f 2 <<< "$1")"
+	USER="$(cut -d '@' -f 1 <<<"$1")"
+	HOST="$(cut -d '@' -f 2 <<<"$1")"
 
 # only user provided, intend to deploy the portable version
 elif [[ ! -z "$1" ]] && [[ -z "$2" ]]; then
-  portable=y
-  USER="${1}"
+	portable=y
+	USER="${1}"
 
 # nothing or both provided
 else
-  USER="${1:-$USER}"
-  HOST="${2:-$HOST}"
-  HOST="$(IFS='.'; parts=($(echo $HOST)); IFS=' '; host=$(for (( idx=\${#parts[@]}-1 ; idx>=0 ; idx-- )) ; do printf \"\${parts[idx]}.\"; done); echo \${host:: -1})"
+	USER="${1:-$USER}"
+	HOST="${2:-$HOST}"
+	HOST="$(
+		IFS='.'
+		parts=($(echo $HOST))
+		IFS=' '
+		host=$(for ((idx = ${#parts[@]} - 1; idx >= 0; idx--)); do printf \"\${parts[idx]}.\"; done)
+		echo \${host:: -1}
+	)"
 fi
 
 if [[ "$portable" == "y" ]]; then
-  attr="$portableattr"
+	attr="$portableattr"
 else
-  attr="$hostattr"
+	attr="$hostattr"
 fi
 
 if [[ "$switch" == "y" ]]; then
-  nix build "$attr" "${@:3}" && result/activate && unlink result
+	nix build "$attr" "${@:3}" && result/activate && unlink result
 else
-  nix build "$attr" "${@:3}"
+	nix build "$attr" "${@:3}"
 fi
-  

--- a/scripts/hosts-rebuild.bash
+++ b/scripts/hosts-rebuild.bash
@@ -2,5 +2,10 @@
 
 HOST="${1:-$HOST}"
 
-attr="$FLAKEROOT#\"$HOST\""
-nixos-rebuild --flake "$attr" "${@:2}"
+attr="$FLAKEROOT#$HOST"
+if [ -x /run/wrappers/bin/sudo ]; then
+	export PATH=/run/wrappers/bin:$PATH
+	sudo nixos-rebuild --flake "$attr" "${@:2}"
+else
+	nixos-rebuild --flake "$attr" "${@:2}"
+fi


### PR DESCRIPTION
Also, we should have a default format for shell script, such as shfmt, beautysh.

Fixes:
`/src/bud/scripts/hm-home.bash:24:82: "expr" must be followed by ;`