### PR TITLE
Fix typo in nixosModule.nix

### DIFF
--- a/nixosModule.nix
+++ b/nixosModule.nix
@@ -9,7 +9,7 @@ bud:
 , ...
 }:
 let
-  reboudBud = bud self;
+  reboundBud = bud self;
   cfg = config.bud;
 in
 with lib; {


### PR DESCRIPTION
Typo in nixosModule.nix causes fail during [divnix/devos](https://www.github.com/divnix/devos) `bud rebuild`