### PR TITLE
`localFlakeClone` as a string shows a warning

### DIFF
--- a/nixosModule.nix
+++ b/nixosModule.nix
@@ -16,9 +16,9 @@ with lib; {
   options.bud = {
     enable = mkEnableOption "enable bud sysctl tool";
     localFlakeClone = mkOption {
-      type = types.string;
+      type = types.path;
       description = ''
-        A string reference to the local (editable) copy
+        A path reference to the local (editable) copy
         of your system flake. This is used as reference
         so that the scripts can do work on your flake,
         such as for example updating inputs.


### PR DESCRIPTION
To be honest I can't understand where `localFlakeClone` is used but it's automatically set by `onboarding-up.bash` so by default when someone creates a configuration from NixOS he gets this warning:
```sh
warning: The type `types.string' of option `bud.localFlakeClone' defined in `<unknown-file>' is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types.
```