### PR TITLE
Remove dependency on beautysh

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,6 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/release-21.11";
     devshell.url = "github:numtide/devshell";
-    beautysh.url = "github:lovesegfault/beautysh";
   };
 
   outputs = { self, nixpkgs, devshell, beautysh, ... }:


### PR DESCRIPTION
According to @GTrunSec we no longer need `beautysh`. It currently cause a build error, so there shouldn't be any reason to keep it.